### PR TITLE
fix: use failure status

### DIFF
--- a/src/events/pull/index.ts
+++ b/src/events/pull/index.ts
@@ -142,7 +142,7 @@ const handleChallengePull = async (
 
   const status = {
     sha: pullRequest.head.sha,
-    state: reply.status === Status.Success ? "success" : "pending",
+    state: reply.status === Status.Success ? "success" : "failure",
     target_url:
       "https://tidb-community-bots.github.io/ti-challenge-bot/commands.html",
     description: reply.message,


### PR DESCRIPTION
If we use the pending status it maybe will block other PR merging.