### PR TITLE
fix: remove reward CI status

### DIFF
--- a/src/services/challenge-pull/index.ts
+++ b/src/services/challenge-pull/index.ts
@@ -96,19 +96,10 @@ export default class ChallengePullService implements IChallengePullService {
    * @param rewardQuery
    */
   public async reward(rewardQuery: RewardQuery): Promise<Reply<null>> {
-    const { pull: pullQuery } = rewardQuery;
     const baseFailedMessage = {
       data: null,
       status: Status.Failed,
     };
-
-    // Check if pull closed.
-    if (pullQuery.state === IssueOrPullStatus.Closed) {
-      return {
-        ...baseFailedMessage,
-        message: ChallengePullMessage.PullRequestAlreadyClosed,
-      };
-    }
 
     // Try to find linked issue.
     const issue = await this.issueRepository.findOne({


### PR DESCRIPTION
This is a hot fix.

R&D does not want this CI check, and we can’t keep commenting on  PR, so I remove the CI status and only check the reward when pr open or reopen. We need to redesign the reward mechanism in the future.

